### PR TITLE
Fix: Correct modal ID in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -932,7 +932,7 @@ def home():
                 }
                 
                 function openNewCustomerModal() {
-                    document.getElementById('newCustomerModalWRONG').style.display = 'block';
+                    document.getElementById('newCustomerModal').style.display = 'block';
                     document.getElementById('newCustomerError').textContent = '';
                     
                     // Clear the form


### PR DESCRIPTION
This PR corrects a bug introduced in the previous commit where the modal ID was incorrectly set to 'newCustomerModalWrong'. It has been updated to 'newCustomerModal'.